### PR TITLE
#1 Extra /etc/ssh/sshd_config hardening

### DIFF
--- a/roles/common/tasks/main.yml
+++ b/roles/common/tasks/main.yml
@@ -121,12 +121,17 @@
   with_items: "{{ sysadmins }}"
   tags: common
 
+- name: assert sysadmins are named
+  fail: msg="sysadmins must be listed"
+  when: not (sysadmins | length)
+
 - name: disable password authentication and root login in sshd_config
   blockinfile:
     dest: /etc/ssh/sshd_config
     marker: "# {mark} ANSIBLE MANAGED BLOCK common"
     block: |
       PermitRootLogin no
+      AllowUsers {{ sysadmins | join(' ') }}
       Match Group wheel
       	PasswordAuthentication no
   register: sshd_config


### PR DESCRIPTION
https://wiki.centos.org/HowTos/Network/SecuringSSH

Only every allow SSH login from named sysadmins.

@carlba, maybe something to add to your [ssh_hardening.yml](https://bitbucket.org/carlba/ansible-servern/src/master/roles/media-server/tasks/ssh_hardening.yml) as well?